### PR TITLE
도표 include 방법 변경 및 스타일 업데이트

### DIFF
--- a/_includes/centered_img.html
+++ b/_includes/centered_img.html
@@ -1,3 +1,0 @@
-<a href="{{ imgsrc }}">
-	<img src="{{ imgsrc }}" style="max-width: 500px; max-height: 500px;" title="{{ imgtitle }}">
-</a>

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,9 +1,11 @@
-<figure>
+<figure class="post-figure">
 	<div class="center-container">
 		<div class="center-content">
-			{% include centered_img.html %}
-			<figcaption style="text-align: center;">
-				{{ figcaption }}
+			<a href='{{ include.src }}'>
+				<img src='{{ include.src }}' title='{{ include.title }}'>
+			</a>	
+			<figcaption>
+				{{ include.figcaption }}
 			</figcaption>
 		</div>
 	</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,15 +5,17 @@
 	<title>{{ page.title }}</title>
 	<link rel="stylesheet" type="text/css" href="{{ "/css/default.css" | prepend: site.base }}">
 </head>
-<body style="margin: 0px;">
-	<div class="center-container" id="navigation-container">
-		<div class="center-content">
-			{% include navigation.html %}
+<body style="margin: 0px; min-width: 1012px;">
+	<div class="menu">
+		<div class="center-container" id="navigation-container">
+			<div class="center-content">
+				{% include navigation.html %}
+			</div>
 		</div>
 	</div>
-	<div style="width: 100%;">
-		<div style="width: 280px; float:left;">
-			<div id="profile-container">
+	<div class="main-container">
+		<div class="main">
+			<div class="float-left" id="profile-container">
 				<a href="about.html" style="width: 100%">
 					<div id="profile-image-container" style="margin: 10%; display: inline-block;">
 						<img src = "/assets/img/profile.png">
@@ -21,10 +23,10 @@
 					<h1 style="text-align: center; color: burlywood;">BreadKey</h1>
 				</a>
 			</div>
-		</div>	
-		<div style="display: table;">
-			<div style="width: 800px; margin: 5%; margin-left: 0px;">	
-				{{ content }}
+			<div id="content-container" class="float-left">
+				<div style="margin: 5%; margin-left: 0px;">	
+					{{ content }}
+				</div>
 			</div>
 		</div>
 	</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
 			</div>
 		</div>	
 		<div style="display: table;">
-			<div style="max-width: 800px; margin: 5%; margin-left: 0px;">	
+			<div style="width: 800px; margin: 5%; margin-left: 0px;">	
 				{{ content }}
 			</div>
 		</div>

--- a/css/default.css
+++ b/css/default.css
@@ -51,11 +51,29 @@ img {
 }
 
 #profile-container {
-	width: 200px;
-	height: 280px;
+	width: 20%;
+	height: 28%;
 	float: right;
 	background-color: dimgray;
+	margin-right: 5%;
+	border-radius: 5%;
+}
+
+#content-container {
+	width: 75%;
+}
+
+.float-left {
+	float: left!important;
+}
+
+.main {
+	max-width: 1012px; 
+	margin-left: auto; 
+	margin-right: auto;
 	margin-top: 20px;
-	margin-right: 20px;
-	border-radius: 20px;
+}
+
+.main div {
+	box-sizing: border-box;
 }

--- a/css/post.css
+++ b/css/post.css
@@ -33,4 +33,6 @@
 
 .post-figure figcaption {
 	text-align: center;
+	font-size: 0.8em;
+	font-style: italic;
 }

--- a/css/post.css
+++ b/css/post.css
@@ -12,3 +12,12 @@
 #post-content {
 	margin: 10px;
 }
+
+#post-content ul {
+	list-style-type: disc;
+	padding-inline-start: 40px;
+}
+
+#post-content li {
+	border-bottom: none;
+}

--- a/css/post.css
+++ b/css/post.css
@@ -21,3 +21,16 @@
 #post-content li {
 	border-bottom: none;
 }
+
+#post-container {
+	border-bottom: 1.5px solid burlywood;
+}
+
+.post-figure img {
+	max-width: 500px;
+	max-height: 500px;
+}
+
+.post-figure figcaption {
+	text-align: center;
+}


### PR DESCRIPTION
기존에 도표 include 방법은 assign을 통해 이미지나 캡션등을 할당하고 할당된 값을 figure.html에서 처리하는 방식이였는데, include시 이미지나 캡션등을 직접 전달하는 방식으로 변경. 스타일은 깃헙처럼 메인 컨텐츠가 다운데에 몰려있는 방식으로 설정
1. 메인 컨텐츠의 내용물이 가운데에 오도록 margin left, right를 auto로 설정
2. 프로필은 도합 25%, 포스트 등 컨텐츠는 75%가 되게함